### PR TITLE
fix(frontend): padroniza verificacao de roles no sidebar para 'administrador (Task #23)

### DIFF
--- a/concilia-backend/src/app/Http/Controllers/Api/DashboardController.php
+++ b/concilia-backend/src/app/Http/Controllers/Api/DashboardController.php
@@ -58,7 +58,7 @@ class DashboardController extends Controller
             $lawyersQuery->where('id', $user->id);
         } else {
             // Admin vê todos os operadores/admins
-            $lawyersQuery->whereIn('role', ['operador', 'admin', 'supervisor']);
+            $lawyersQuery->whereIn('role', ['operador', 'administrador', 'supervisor']);
         }
         
         $lawyers = $lawyersQuery->get();

--- a/concilia-backend/src/app/Policies/UserPolicy.php
+++ b/concilia-backend/src/app/Policies/UserPolicy.php
@@ -14,7 +14,7 @@ class UserPolicy
      */
     public function viewAny(User $user): bool
     {
-        return in_array($user->role, ['administrador', 'admin', 'supervisor', 'operador']);
+        return in_array($user->role, ['administrador', 'supervisor', 'operador']);
     }
 
     /**
@@ -23,7 +23,7 @@ class UserPolicy
      */
     public function view(User $user, User $model): bool
     {
-        if (in_array($user->role, ['administrador', 'admin', 'supervisor'])) {
+        if (in_array($user->role, ['administrador', 'supervisor'])) {
             return true;
         }
         // Operador só vê a si mesmo
@@ -36,7 +36,7 @@ class UserPolicy
      */
     public function create(User $user): bool
     {
-        return in_array($user->role, ['administrador', 'admin', 'supervisor']);
+        return in_array($user->role, ['administrador', 'supervisor']);
     }
 
     /**
@@ -45,7 +45,7 @@ class UserPolicy
      */
     public function update(User $user, User $model): bool
     {
-        return in_array($user->role, ['administrador', 'admin', 'supervisor']);
+        return in_array($user->role, ['administrador', 'supervisor']);
     }
 
     /**
@@ -55,7 +55,7 @@ class UserPolicy
     public function delete(User $user, User $model): bool
     {
         // 1. Apenas Admin pode excluir
-        if (!in_array($user->role, ['administrador', 'admin'])) {
+        if (!in_array($user->role, ['administrador'])) {
             return false;
         }
 

--- a/concilia-backend/src/database/migrations/2025_12_11_144520_fix_legacy_user_roles.php
+++ b/concilia-backend/src/database/migrations/2025_12_11_144520_fix_legacy_user_roles.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Atualiza todos os usuários 'admin' para 'administrador'
+        DB::table('users')
+            ->where('role', 'admin')
+            ->update(['role' => 'administrador']);
+    }
+
+    public function down(): void
+    {
+        // Reverte (opcional, mas boa prática)
+        DB::table('users')
+            ->where('role', 'administrador')
+            ->update(['role' => 'admin']);
+    }
+};

--- a/concilia-backend/src/database/seeders/UserSeeder.php
+++ b/concilia-backend/src/database/seeders/UserSeeder.php
@@ -16,7 +16,7 @@ class UserSeeder extends Seeder
                 'name' => 'Admin Sistema',
                 'email' => 'admin@concilia.app',
                 'password' => Hash::make('password'),
-                'role' => 'admin', 
+                'role' => 'administrador', 
                 'status' => 'ativo',
                 'created_at' => now(),
                 'updated_at' => now(),

--- a/concilia-frontend/src/components/MainLayout.jsx
+++ b/concilia-frontend/src/components/MainLayout.jsx
@@ -18,8 +18,8 @@ const MainLayout = () => {
         return `${styles.navLink} ${isActive ? styles.navLinkActive : ''}`;
     };
 
-    const isAdmin = user?.role === 'admin';
-    const canManageUsers = user?.role === 'admin' || user?.role === 'supervisor';
+    const isAdmin = user?.role === 'administrador';
+    const canManageUsers = user?.role === 'administrador' || user?.role === 'supervisor';
 
     return (
         <div className={styles.layoutContainer}>

--- a/concilia-frontend/src/pages/UserManagementPage.jsx
+++ b/concilia-frontend/src/pages/UserManagementPage.jsx
@@ -16,7 +16,7 @@ const ROLE_DETAILS = {
     'administrador': { name: 'Administrador', color: '#9f7aea', textColor: '#FFFFFF' },
     'supervisor': { name: 'Supervisor', color: '#ed8936', textColor: '#FFFFFF' },
     'operador': { name: 'Operador', color: '#4299e1', textColor: '#FFFFFF' },
-    'admin': { name: 'Administrador', color: '#9f7aea', textColor: '#FFFFFF' },
+    
 };
 
 const StatusTag = ({ status }) => {
@@ -31,7 +31,7 @@ const RoleTag = ({ role }) => {
 
 const UserManagementPage = () => {
     const { token, user } = useAuth();
-    const canManage = ['administrador', 'admin', 'supervisor'].includes(user?.role);
+    const canManage = ['administrador', 'supervisor'].includes(user?.role);
 
     const [users, setUsers] = useState([]);
     const [departments, setDepartments] = useState([]);
@@ -210,7 +210,7 @@ const UserManagementPage = () => {
                 </select>
                 <select name="role" className={styles.filterSelect} value={filters.role} onChange={handleFilterChange}>
                     <option value="">Função: Todas</option>
-                    <option value="administrador">Admin</option>
+                    <option value="administrador">Administrador</option>
                     <option value="supervisor">Supervisor</option>
                     <option value="operador">Operador</option>
                 </select>
@@ -317,7 +317,7 @@ const UserManagementPage = () => {
                                     <select value={formData.role} onChange={e => setFormData({...formData, role: e.target.value})}>
                                         <option value="operador">Operador</option>
                                         <option value="supervisor">Supervisor</option>
-                                        <option value="administrador">Admin</option>
+                                        <option value="administrador">Administrador</option>
                                     </select>
                                 </div>
                                 <div className={styles.formGroup}>


### PR DESCRIPTION
### Padronização de Roles (Dívida Técnica) #23

Correção de dívida técnica para padronizar a nomenclatura de cargos (roles) em todo o sistema. Historicamente, o sistema aceitava admin e administrador. Para evitar inconsistências de permissão e bugs visuais, o termo admin foi depreciado e substituído definitivamente por administrador no Banco de Dados, Backend e Frontend.

📂 Detalhamento Técnico (Arquivos Modificados/Criados):

1. Banco de Dados

concilia-backend/src/database/migrations/YYYY_MM_DD_fix_legacy_user_roles.php (Arquivo Criado):

Migration responsável por varrer a tabela users e atualizar qualquer registro com role admin para administrador.

2. Backend (Laravel)

concilia-backend/src/app/Policies/UserPolicy.php (Modificado):

Removida a string 'admin' das validações de in_array. Agora a segurança valida estritamente 'administrador'.

concilia-backend/src/app/Http/Controllers/Api/DashboardController.php (Modificado):

Ajustados os filtros de query da Dashboard para buscar apenas por administrador ao calcular métricas de equipe.

3. Frontend (React)

concilia-frontend/src/components/MainLayout.jsx (Modificado):

Atualizada a lógica de renderização do Menu Lateral (Sidebar). A verificação isAdmin e canManageUsers agora compara estritamente com administrador. Isso corrige o bug onde o menu sumia para usuários migrados.

concilia-frontend/src/pages/UserManagementPage.jsx (Modificado):

Removida a entrada duplicada 'admin' do objeto ROLE_DETAILS.

Atualizada a constante canManage para remover suporte ao cargo legado.

✅ Validação:

Migration: Executada com sucesso, convertendo usuários antigos.

Acesso: Usuário Admin consegue logar e visualizar todos os menus (Dashboard, Gestão de Usuários, Logs) corretamente após a mudança.

Segurança: As regras de ACL continuam funcionando perfeitamente com a nova nomenclatura.

Closes #23