### PR TITLE
Feat: Implementação de Troca de Senha Obrigatória (Fixes #30, #32)

### DIFF
--- a/concilia-backend/src/app/Http/Controllers/Api/AuthController.php
+++ b/concilia-backend/src/app/Http/Controllers/Api/AuthController.php
@@ -95,20 +95,21 @@ class AuthController extends Controller
 
     $user = $request->user();
 
-    // Verifica se a senha atual bate com o banco
     if (!Hash::check($request->current_password, $user->password)) {
-        return response()->json(['message' => 'A senha atual está incorreta.'], 422);
-    }
-    // 2. NOVO: Verifica se a nova senha é IGUAL à antiga (Bloqueio)
+            return response()->json(['message' => 'A senha atual está incorreta.'], 422);
+        }
+
+        // Bloqueio de senha igual (que sugerimos antes)
         if (Hash::check($request->new_password, $user->password)) {
             return response()->json(['message' => 'A nova senha não pode ser igual à atual.'], 422);
         }
 
-    // Atualiza
-    $user->update([
-        'password' => Hash::make($request->new_password)
-    ]);
+        // ATUALIZAÇÃO
+        $user->update([
+            'password' => Hash::make($request->new_password),
+            'must_change_password' => false // <--- AQUI: Libera o usuário!
+        ]);
 
-    return response()->json(['message' => 'Senha alterada com sucesso!']);
-}
+        return response()->json(['message' => 'Senha alterada com sucesso! Você já pode navegar no sistema.']);
+    }
 }

--- a/concilia-backend/src/app/Models/User.php
+++ b/concilia-backend/src/app/Models/User.php
@@ -29,6 +29,7 @@ class User extends Authenticatable
         'phone',
         'last_login_at',
         'department_id',
+        'must_change_password',
     ];
 
     /**
@@ -47,6 +48,7 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         
         'last_login_at' => 'datetime', // NOVO CAST ADICIONADO
+        'must_change_password' => 'boolean',
     ];
 
     /**

--- a/concilia-backend/src/database/migrations/2025_12_30_111240_add_must_change_password_to_users_table.php
+++ b/concilia-backend/src/database/migrations/2025_12_30_111240_add_must_change_password_to_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+  public function up(): void
+{
+    Schema::table('users', function (Blueprint $table) {
+        // Default false para não bloquear os atuais, mas para novos usuários criados
+        // via Admin, você setará como true manualmente no create.
+        $table->boolean('must_change_password')->default(false);
+    });
+}
+
+public function down(): void
+{
+    Schema::table('users', function (Blueprint $table) {
+        $table->dropColumn('must_change_password');
+    });
+}
+};

--- a/concilia-backend/src/routes/api.php
+++ b/concilia-backend/src/routes/api.php
@@ -18,6 +18,7 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
 
 Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/change-password', [AuthController::class, 'changePassword']);
     Route::put('/auth/change-password', [AuthController::class, 'changePassword']);
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/user', fn(Request $request) => $request->user());

--- a/concilia-frontend/src/App.jsx
+++ b/concilia-frontend/src/App.jsx
@@ -18,6 +18,7 @@ import CaseCreatePage from './pages/CaseCreatePage';
 import UserManagementPage from './pages/UserManagementPage';
 import InboxPage from './pages/InboxPage';
 import ConversationDetailPage from './pages/ConversationDetailPage';
+import ForceChangePassword from './pages/ForceChangePassword';
 
 
 

--- a/concilia-frontend/src/api.js
+++ b/concilia-frontend/src/api.js
@@ -16,7 +16,7 @@ const apiClient = axios.create({
 // Interceptor para adicionar o token em todas as requisições
 apiClient.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('authToken');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/concilia-frontend/src/components/ProtectedRoute.jsx
+++ b/concilia-frontend/src/components/ProtectedRoute.jsx
@@ -1,15 +1,40 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import ForceChangePassword from '../pages/ForceChangePassword';
 
 const ProtectedRoute = ({ children }) => {
-  const { user } = useAuth();
+  // Pegamos o user e o loading. 
+  // O "authenticated" removemos pois pode não existir no seu contexto.
+  const { user, loading } = useAuth();
 
+  // 1. Debug: Vamos ver no console o que está chegando
+  console.log("ProtectedRoute - User:", user);
+  console.log("ProtectedRoute - Loading:", loading);
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '50px' }}>
+        Carregando sistema...
+      </div>
+    );
+  }
+
+  // 2. Verificação de Segurança:
+  // Se não tem usuário (user é null ou false), manda pro login.
   if (!user) {
-    // Se não houver usuário, redireciona para a página de login
+    console.warn("Acesso negado: Usuário não detectado.");
     return <Navigate to="/login" />;
   }
 
+  // 3. Regra de Troca de Senha Obrigatória:
+  // Verifica se o user existe E se a flag must_change_password é verdadeira
+  if (user && (user.must_change_password === true || user.must_change_password === 1)) {
+    console.log("Bloqueio de Segurança: Troca de senha obrigatória.");
+    return <ForceChangePassword />;
+  }
+
+  // 4. Se passou por tudo, libera o acesso à rota (Dashboard, etc)
   return children;
 };
 

--- a/concilia-frontend/src/pages/ForceChangePassword.jsx
+++ b/concilia-frontend/src/pages/ForceChangePassword.jsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+
+const ForceChangePassword = () => {
+  const { logout, user, setUser } = useAuth(); // Precisa de setUser no AuthContext (veja nota abaixo)
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    current_password: '',
+    new_password: '',
+    new_password_confirmation: ''
+  });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      // 1. Envia a requisição para o Backend (Isso já estava funcionando)
+      await api.post('/change-password', formData);
+      
+      // 2. MÁGICA: Atualiza o usuário na memória do navegador e do React
+      // Cria um clone do usuário atual, mas forçando o bloqueio para FALSE
+      const updatedUser = { ...user, must_change_password: false };
+      
+      // Salva no LocalStorage (chave 'user' conforme vimos no seu print)
+      localStorage.setItem('user', JSON.stringify(updatedUser));
+      
+      // Atualiza o Contexto do React (Se existir a função setUser)
+      if (setUser) {
+        setUser(updatedUser);
+      }
+
+      // 3. Feedback Visual e Redirecionamento
+      alert('Senha alterada com sucesso! Você será redirecionado.');
+      
+      // Força um recarregamento da página para garantir que o sistema leia os dados novos
+      window.location.href = '/dashboard';
+
+    } catch (err) {
+      // Se der erro (senha errada, etc), mostra na tela
+      console.error(err);
+      setError(err.response?.data?.message || 'Erro ao alterar senha');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f3f4f6' }}>
+      <div style={{ background: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 2px 10px rgba(0,0,0,0.1)', maxWidth: '400px', width: '100%' }}>
+        <h2 style={{ color: '#d32f2f', marginBottom: '1rem', textAlign: 'center' }}>⚠️ Alteração Obrigatória</h2>
+        <p style={{ marginBottom: '1.5rem', color: '#666', fontSize: '0.9rem', textAlign: 'center' }}>
+          Por motivos de segurança, você precisa definir uma nova senha antes de continuar.
+        </p>
+
+        {error && <div style={{ color: 'red', marginBottom: '1rem', fontSize: '0.9rem', textAlign: 'center' }}>{error}</div>}
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={{ display: 'block', fontSize: '0.8rem', color: '#555' }}>Senha Atual (Padrão)</label>
+            <input 
+              type="password" 
+              required
+              className="form-control" // Se usar Bootstrap, senão estilize básico
+              style={{ width: '100%', padding: '8px', marginTop: '4px', border: '1px solid #ddd', borderRadius: '4px' }}
+              value={formData.current_password}
+              onChange={e => setFormData({...formData, current_password: e.target.value})}
+            />
+          </div>
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={{ display: 'block', fontSize: '0.8rem', color: '#555' }}>Nova Senha</label>
+            <input 
+              type="password" 
+              required
+              minLength={8}
+              style={{ width: '100%', padding: '8px', marginTop: '4px', border: '1px solid #ddd', borderRadius: '4px' }}
+              value={formData.new_password}
+              onChange={e => setFormData({...formData, new_password: e.target.value})}
+            />
+          </div>
+          <div style={{ marginBottom: '1.5rem' }}>
+            <label style={{ display: 'block', fontSize: '0.8rem', color: '#555' }}>Confirmar Nova Senha</label>
+            <input 
+              type="password" 
+              required
+              style={{ width: '100%', padding: '8px', marginTop: '4px', border: '1px solid #ddd', borderRadius: '4px' }}
+              value={formData.new_password_confirmation}
+              onChange={e => setFormData({...formData, new_password_confirmation: e.target.value})}
+            />
+          </div>
+          
+          <button 
+            type="submit" 
+            disabled={loading}
+            style={{ width: '100%', padding: '10px', background: '#4f46e5', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
+          >
+            {loading ? 'Salvando...' : 'Definir Nova Senha'}
+          </button>
+        </form>
+        
+        <button onClick={logout} style={{ width: '100%', marginTop: '1rem', background: 'transparent', border: 'none', color: '#666', cursor: 'pointer', textDecoration: 'underline' }}>
+          Sair da conta
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ForceChangePassword;


### PR DESCRIPTION
Este PR implementa a política de segurança que obriga usuários recém-criados (ou resetados) a definirem uma senha pessoal antes de acessarem o sistema.

Contexto: Usuários criados administrativamente recebem uma senha padrão insegura. As issues #30 e #32 solicitavam um mecanismo para bloquear a navegação até que essa senha fosse alterada.

Solução: Foi criada uma flag must_change_password no banco de dados. O Frontend intercepta o login e, se essa flag for true, redireciona o usuário para uma tela de bloqueio exclusiva, impedindo o acesso ao Dashboard e outras rotas protegidas até a regularização.

🔗 Tarefas Relacionadas
Closes #30

Closes #32

🛠️ Alterações Técnicas
Backend (Laravel):

Database: Nova migration add_must_change_password_to_users_table (default: false).

Model (User.php): Adicionado campo must_change_password ao $fillable e configurado $casts para boolean.

Controller (AuthController.php):

Adicionada verificação para impedir que a nova senha seja igual à atual.

Atualização da senha agora define must_change_password = false automaticamente.

Rotas (api.php): Registro da rota protegida POST /change-password.

Frontend (React):

Componente (ProtectedRoute.jsx): Refatorado para checar a flag do usuário. Se must_change_password for true, renderiza o componente de bloqueio em vez da rota solicitada.

Página (ForceChangePassword.jsx): [NOVO] Tela de formulário que obriga a troca de senha. Inclui lógica para atualizar o localStorage e o contexto imediatamente após o sucesso.

Config (api.js): Correção no Interceptor do Axios para usar a chave correta authToken do LocalStorage, resolvendo erro 401.

🧪 Plano de Teste
Setup: Rodar migrations (php artisan migrate).

Cenário de Bloqueio:

No Tinker, forçar um usuário a trocar senha: User::where('email', '...')->update(['must_change_password' => true]).

Fazer login com este usuário.

Resultado Esperado: O usuário deve ser barrado na tela "Alteração Obrigatória". Tentar mudar a URL manualmente (ex: /dashboard) deve redirecionar de volta para o bloqueio.

Cenário de Desbloqueio:

Preencher a nova senha na tela de bloqueio e enviar.

Resultado Esperado: Mensagem de sucesso, atualização do estado local e redirecionamento automático para o Dashboard.

📸 Evidências (Screenshots)
1. Tela de Bloqueio (Usuário interceptado): <img width="830" height="621" alt="image" src="https://github.com/user-attachments/assets/48a38db1-77ad-4323-b330-cda37eed2536" />

