### PR TITLE
New filter dash

### DIFF
--- a/concilia-backend/src/app/Http/Controllers/Api/DashboardController.php
+++ b/concilia-backend/src/app/Http/Controllers/Api/DashboardController.php
@@ -16,6 +16,11 @@ use Illuminate\Support\Facades\DB;
 class DashboardController extends Controller
 {
     private const TEAM_ROLES = ['operador', 'administrador', 'supervisor'];
+    private const METRIC_PERIOD_LABELS = [
+        'day' => 'Dia',
+        'week' => 'Semana',
+        'month' => 'Mes',
+    ];
     private const BRAZIL_STATES = [
         'AC' => 'Acre',
         'AL' => 'Alagoas',
@@ -137,6 +142,7 @@ class DashboardController extends Controller
             : 0;
         $indicatorLeaderboard = $this->buildIndicatorLeaderboard($request, $user, $portfolioDateRange);
         $recentCases = $this->buildRecentCases($request, $user, $portfolioDateRange);
+        $viewMetrics = $this->buildViewMetrics($request, $user, $closingDateRange);
 
         return response()->json([
             'kpis' => [
@@ -171,8 +177,130 @@ class DashboardController extends Controller
             'agreement_macro_distribution' => $this->buildAgreementMacroDistribution($request, $user, $closingDateRange),
             'indicator_leaderboard' => $indicatorLeaderboard,
             'team_performance' => $this->buildTeamPerformance($request, $user, $portfolioDateRange),
+            'view_metrics' => $viewMetrics,
             'recent_cases' => $recentCases,
         ]);
+    }
+
+    private function buildViewMetrics(Request $request, User $user, array $closingDateRange): array
+    {
+        $views = [
+            'general' => [],
+            'by_responsible' => [],
+            'by_indicator' => [],
+        ];
+
+        foreach (array_keys(self::METRIC_PERIOD_LABELS) as $periodKey) {
+            $periodRange = $this->mergeDateRanges(
+                $closingDateRange,
+                $this->resolveMetricPeriodRange($periodKey)
+            );
+            $periodPayload = $this->buildMetricPeriodPayload($periodKey, $periodRange);
+            $responsibleItems = $this->buildResponsibleMetricItems($request, $user, $periodRange);
+            $indicatorItems = $this->buildIndicatorMetricItems($request, $user, $periodRange);
+
+            $views['general'][$periodKey] = [
+                'period' => $periodPayload,
+                'summary' => $this->buildGeneralMetricSummary($request, $user, $periodRange),
+            ];
+            $views['by_responsible'][$periodKey] = [
+                'period' => $periodPayload,
+                'summary' => $this->buildGroupedMetricSummary($responsibleItems),
+                'items' => $responsibleItems,
+            ];
+            $views['by_indicator'][$periodKey] = [
+                'period' => $periodPayload,
+                'summary' => $this->buildGroupedMetricSummary($indicatorItems),
+                'items' => $indicatorItems,
+            ];
+        }
+
+        return $views;
+    }
+
+    private function buildGeneralMetricSummary(Request $request, User $user, array $dateRange): array
+    {
+        $summary = $this->newClosedDealsQuery($request, $user, $dateRange, 'agreement_closed_at')
+            ->selectRaw('COUNT(*) as agreements_count')
+            ->selectRaw('COALESCE(SUM(COALESCE(agreement_value, 0)), 0) as total_agreement_value')
+            ->selectRaw(
+                'COALESCE(AVG(CASE WHEN COALESCE(agreement_value, 0) > 0 THEN agreement_value END), 0) as average_ticket'
+            )
+            ->selectRaw(
+                'COALESCE(SUM(COALESCE(original_value, 0) - COALESCE(agreement_value, 0)), 0) as total_economy'
+            )
+            ->selectRaw(
+                "COALESCE(SUM(CASE WHEN JSON_EXTRACT(agreement_checklist_data, '$.indication_checklist') IS NOT NULL THEN 1 ELSE 0 END), 0) as converted_indications_count"
+            )
+            ->first();
+
+        return [
+            'agreements_count' => (int) ($summary->agreements_count ?? 0),
+            'total_agreement_value' => (float) ($summary->total_agreement_value ?? 0),
+            'average_ticket' => (float) ($summary->average_ticket ?? 0),
+            'total_economy' => (float) ($summary->total_economy ?? 0),
+            'converted_indications_count' => (int) ($summary->converted_indications_count ?? 0),
+        ];
+    }
+
+    private function buildResponsibleMetricItems(Request $request, User $user, array $dateRange): array
+    {
+        return $this->newClosedDealsQuery($request, $user, $dateRange, 'agreement_closed_at')
+            ->leftJoin('users', 'users.id', '=', 'legal_cases.user_id')
+            ->selectRaw('legal_cases.user_id as entity_id')
+            ->selectRaw("COALESCE(users.name, 'Responsavel indisponivel') as entity_name")
+            ->selectRaw('COUNT(*) as agreements_count')
+            ->selectRaw(
+                "COALESCE(SUM(CASE WHEN JSON_EXTRACT(legal_cases.agreement_checklist_data, '$.indication_checklist') IS NOT NULL THEN 1 ELSE 0 END), 0) as converted_indications_count"
+            )
+            ->groupBy('legal_cases.user_id', 'users.name')
+            ->orderByDesc('agreements_count')
+            ->orderByDesc('converted_indications_count')
+            ->orderBy('entity_name')
+            ->get()
+            ->map(fn ($row) => [
+                'id' => (int) ($row->entity_id ?? 0),
+                'name' => $row->entity_name,
+                'agreements_count' => (int) ($row->agreements_count ?? 0),
+                'converted_indications_count' => (int) ($row->converted_indications_count ?? 0),
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function buildIndicatorMetricItems(Request $request, User $user, array $dateRange): array
+    {
+        return $this->newClosedDealsQuery($request, $user, $dateRange, 'agreement_closed_at')
+            ->leftJoin('users as indicators', 'indicators.id', '=', 'legal_cases.indicator_user_id')
+            ->whereNotNull('legal_cases.indicator_user_id')
+            ->selectRaw('legal_cases.indicator_user_id as entity_id')
+            ->selectRaw("COALESCE(indicators.name, 'Indicador indisponivel') as entity_name")
+            ->selectRaw('COUNT(*) as agreements_count')
+            ->selectRaw(
+                "COALESCE(SUM(CASE WHEN JSON_EXTRACT(legal_cases.agreement_checklist_data, '$.indication_checklist') IS NOT NULL THEN 1 ELSE 0 END), 0) as converted_indications_count"
+            )
+            ->groupBy('legal_cases.indicator_user_id', 'indicators.name')
+            ->orderByDesc('agreements_count')
+            ->orderByDesc('converted_indications_count')
+            ->orderBy('entity_name')
+            ->get()
+            ->map(fn ($row) => [
+                'id' => (int) ($row->entity_id ?? 0),
+                'name' => $row->entity_name,
+                'agreements_count' => (int) ($row->agreements_count ?? 0),
+                'converted_indications_count' => (int) ($row->converted_indications_count ?? 0),
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function buildGroupedMetricSummary(array $items): array
+    {
+        return [
+            'participants_count' => count($items),
+            'agreements_count' => array_sum(array_map(fn (array $item) => (int) ($item['agreements_count'] ?? 0), $items)),
+            'converted_indications_count' => array_sum(array_map(fn (array $item) => (int) ($item['converted_indications_count'] ?? 0), $items)),
+        ];
     }
 
     private function buildTeamPerformance(Request $request, User $user, array $dateRange): array
@@ -644,6 +772,71 @@ class DashboardController extends Controller
         return [
             'start' => $today->copy()->startOfDay(),
             'end' => $today->copy()->endOfDay(),
+        ];
+    }
+
+    private function resolveMetricPeriodRange(string $periodKey): array
+    {
+        $reference = now();
+
+        return match ($periodKey) {
+            'week' => [
+                'start' => $reference->copy()->startOfWeek(Carbon::MONDAY)->startOfDay(),
+                'end' => $reference->copy()->endOfWeek(Carbon::SUNDAY)->endOfDay(),
+            ],
+            'month' => [
+                'start' => $reference->copy()->startOfMonth()->startOfDay(),
+                'end' => $reference->copy()->endOfMonth()->endOfDay(),
+            ],
+            default => [
+                'start' => $reference->copy()->startOfDay(),
+                'end' => $reference->copy()->endOfDay(),
+            ],
+        };
+    }
+
+    private function mergeDateRanges(array $primaryRange, array $secondaryRange): array
+    {
+        $primaryStart = ($primaryRange['start'] ?? null) instanceof Carbon
+            ? $primaryRange['start']->copy()
+            : null;
+        $primaryEnd = ($primaryRange['end'] ?? null) instanceof Carbon
+            ? $primaryRange['end']->copy()
+            : null;
+        $secondaryStart = ($secondaryRange['start'] ?? null) instanceof Carbon
+            ? $secondaryRange['start']->copy()
+            : null;
+        $secondaryEnd = ($secondaryRange['end'] ?? null) instanceof Carbon
+            ? $secondaryRange['end']->copy()
+            : null;
+
+        $start = $primaryStart;
+        if ($secondaryStart instanceof Carbon && (!($start instanceof Carbon) || $secondaryStart->gt($start))) {
+            $start = $secondaryStart;
+        }
+
+        $end = $primaryEnd;
+        if ($secondaryEnd instanceof Carbon && (!($end instanceof Carbon) || $secondaryEnd->lt($end))) {
+            $end = $secondaryEnd;
+        }
+
+        return [
+            'start' => $start,
+            'end' => $end,
+        ];
+    }
+
+    private function buildMetricPeriodPayload(string $periodKey, array $dateRange): array
+    {
+        return [
+            'key' => $periodKey,
+            'label' => self::METRIC_PERIOD_LABELS[$periodKey] ?? ucfirst($periodKey),
+            'start_date' => ($dateRange['start'] ?? null) instanceof Carbon
+                ? $dateRange['start']->toDateString()
+                : null,
+            'end_date' => ($dateRange['end'] ?? null) instanceof Carbon
+                ? $dateRange['end']->toDateString()
+                : null,
         ];
     }
 

--- a/concilia-backend/src/tests/Feature/DashboardMetricsTest.php
+++ b/concilia-backend/src/tests/Feature/DashboardMetricsTest.php
@@ -487,6 +487,128 @@ class DashboardMetricsTest extends TestCase
             ]);
     }
 
+    public function test_dashboard_returns_day_week_and_month_metrics_for_general_responsible_and_indicator_views(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-04-15 10:00:00'));
+
+        try {
+            $manager = User::factory()->create([
+                'role' => 'administrador',
+                'status' => 'ativo',
+            ]);
+
+            $firstOperator = User::factory()->create([
+                'name' => 'Responsavel Um',
+                'role' => 'operador',
+                'status' => 'ativo',
+            ]);
+
+            $secondOperator = User::factory()->create([
+                'name' => 'Responsavel Dois',
+                'role' => 'operador',
+                'status' => 'ativo',
+            ]);
+
+            $firstIndicator = User::factory()->create([
+                'name' => 'Indicador Um',
+                'role' => 'indicador',
+                'status' => 'ativo',
+            ]);
+
+            $secondIndicator = User::factory()->create([
+                'name' => 'Indicador Dois',
+                'role' => 'indicador',
+                'status' => 'ativo',
+            ]);
+
+            Sanctum::actingAs($manager);
+
+            $this->createLegalCase($firstOperator, LegalCase::STATUS_CLOSED_DEAL, 'VIEW-DAY', [
+                'original_value' => 2000,
+                'agreement_value' => 1200,
+                'agreement_closed_at' => '2026-04-15',
+                'indicator_user_id' => $firstIndicator->id,
+                'agreement_checklist_data' => [
+                    'indication_checklist' => [
+                        'completed_at' => '2026-04-10T09:00:00-03:00',
+                    ],
+                ],
+            ]);
+
+            $this->createLegalCase($firstOperator, LegalCase::STATUS_CLOSED_DEAL, 'VIEW-WEEK', [
+                'original_value' => 1600,
+                'agreement_value' => 900,
+                'agreement_closed_at' => '2026-04-14',
+            ]);
+
+            $this->createLegalCase($secondOperator, LegalCase::STATUS_CLOSED_DEAL, 'VIEW-MONTH', [
+                'original_value' => 2600,
+                'agreement_value' => 1500,
+                'agreement_closed_at' => '2026-04-05',
+                'indicator_user_id' => $secondIndicator->id,
+                'agreement_checklist_data' => [
+                    'indication_checklist' => [
+                        'completed_at' => '2026-04-04T15:30:00-03:00',
+                    ],
+                ],
+            ]);
+
+            $this->createLegalCase($secondOperator, LegalCase::STATUS_CLOSED_DEAL, 'VIEW-OUTSIDE', [
+                'agreement_value' => 800,
+                'agreement_closed_at' => '2026-03-28',
+                'indicator_user_id' => $firstIndicator->id,
+                'agreement_checklist_data' => [
+                    'indication_checklist' => [
+                        'completed_at' => '2026-03-20T11:30:00-03:00',
+                    ],
+                ],
+            ]);
+
+            $response = $this->getJson('/api/dashboard');
+
+            $response
+                ->assertOk()
+                ->assertJsonPath('view_metrics.general.day.period.start_date', '2026-04-15')
+                ->assertJsonPath('view_metrics.general.day.summary.agreements_count', 1)
+                ->assertJsonPath('view_metrics.general.day.summary.total_agreement_value', 1200.0)
+                ->assertJsonPath('view_metrics.general.day.summary.average_ticket', 1200.0)
+                ->assertJsonPath('view_metrics.general.day.summary.total_economy', 800.0)
+                ->assertJsonPath('view_metrics.general.day.summary.converted_indications_count', 1)
+                ->assertJsonPath('view_metrics.general.week.period.start_date', '2026-04-13')
+                ->assertJsonPath('view_metrics.general.week.summary.agreements_count', 2)
+                ->assertJsonPath('view_metrics.general.week.summary.total_agreement_value', 2100.0)
+                ->assertJsonPath('view_metrics.general.week.summary.average_ticket', 1050.0)
+                ->assertJsonPath('view_metrics.general.week.summary.total_economy', 1500.0)
+                ->assertJsonPath('view_metrics.general.week.summary.converted_indications_count', 1)
+                ->assertJsonPath('view_metrics.general.month.period.start_date', '2026-04-01')
+                ->assertJsonPath('view_metrics.general.month.summary.agreements_count', 3)
+                ->assertJsonPath('view_metrics.general.month.summary.total_agreement_value', 3600.0)
+                ->assertJsonPath('view_metrics.general.month.summary.average_ticket', 1200.0)
+                ->assertJsonPath('view_metrics.general.month.summary.total_economy', 2600.0)
+                ->assertJsonPath('view_metrics.general.month.summary.converted_indications_count', 2)
+                ->assertJsonPath('view_metrics.by_responsible.month.summary.participants_count', 2)
+                ->assertJsonPath('view_metrics.by_responsible.month.items.0.name', 'Responsavel Um')
+                ->assertJsonPath('view_metrics.by_responsible.month.items.0.agreements_count', 2)
+                ->assertJsonPath('view_metrics.by_responsible.month.items.0.converted_indications_count', 1)
+                ->assertJsonPath('view_metrics.by_responsible.month.items.1.name', 'Responsavel Dois')
+                ->assertJsonPath('view_metrics.by_responsible.month.items.1.agreements_count', 1)
+                ->assertJsonPath('view_metrics.by_responsible.month.items.1.converted_indications_count', 1)
+                ->assertJsonPath('view_metrics.by_indicator.month.summary.participants_count', 2)
+                ->assertJsonFragment([
+                    'name' => 'Indicador Um',
+                    'agreements_count' => 1,
+                    'converted_indications_count' => 1,
+                ])
+                ->assertJsonFragment([
+                    'name' => 'Indicador Dois',
+                    'agreements_count' => 1,
+                    'converted_indications_count' => 1,
+                ]);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     private function createLegalCase(User $operator, string $status, string $caseNumber, array $overrides = []): LegalCase
     {
         $client = Client::firstOrCreate([

--- a/concilia-frontend/src/pages/DashboardPage.jsx
+++ b/concilia-frontend/src/pages/DashboardPage.jsx
@@ -50,12 +50,54 @@ const INDICATION_KPI_ORDER = [
     'indication_flow_conversion_rate',
 ];
 
+const METRIC_VIEW_OPTIONS = [
+    { key: 'general', label: 'Visão geral' },
+    { key: 'by_responsible', label: 'Por Responsável' },
+    { key: 'by_indicator', label: 'Por Indicador' },
+];
+
+const METRIC_PERIOD_OPTIONS = [
+    { key: 'day', label: 'Dia' },
+    { key: 'week', label: 'Semana' },
+    { key: 'month', label: 'Mês' },
+];
+
+const GENERAL_PERIOD_METRIC_CARDS = [
+    {
+        key: 'agreements_count',
+        title: 'Acordos fechados',
+        description: 'Fechamentos do período selecionado',
+    },
+    {
+        key: 'converted_indications_count',
+        title: 'Indicações convertidas',
+        description: 'Casos indicados que chegaram a acordo',
+    },
+    {
+        key: 'total_agreement_value',
+        title: 'Total em valores de acordos',
+        description: 'Somatório dos acordos fechados no período',
+    },
+    {
+        key: 'average_ticket',
+        title: 'Ticket médio',
+        description: 'Média do valor dos acordos fechados',
+    },
+    {
+        key: 'total_economy',
+        title: 'Economia gerada',
+        description: 'Diferença entre valor original e valor acordado',
+    },
+];
+
 const DashboardPage = () => {
     const { token, user } = useAuth();
 
     // LÓGICA DE PERMISSÃO
     const role = user?.role ? user.role.toLowerCase() : '';
     const isManager = role.includes('admin') || role.includes('supervisor') || role.includes('gerente');
+    const isOperator = role.includes('operador');
+    const canUsePeriodFilters = isManager || isOperator;
 
     const [dashboardData, setDashboardData] = useState(null);
     const [cases, setCases] = useState([]);
@@ -90,16 +132,18 @@ const DashboardPage = () => {
     const [isCasesListModalOpen, setIsCasesListModalOpen] = useState(false);
     const [modalStatusKey, setModalStatusKey] = useState(null);
     const [modalStatusName, setModalStatusName] = useState('');
+    const [selectedMetricsView, setSelectedMetricsView] = useState('general');
+    const [selectedMetricsPeriod, setSelectedMetricsPeriod] = useState('day');
 
-    const activeFilterCount = [
+    const activeFilterValues = [
         portfolioStartDate,
         portfolioEndDate,
         closingStartDate,
         closingEndDate,
-        selectedClient,
-        selectedLawyer,
-        selectedStatus,
-    ]
+        ...(isManager ? [selectedClient, selectedLawyer, selectedStatus] : []),
+    ];
+
+    const activeFilterCount = activeFilterValues
         .filter(Boolean)
         .length;
 
@@ -136,13 +180,27 @@ const DashboardPage = () => {
     const selectedLawyerName = lawyers.find((lawyer) => String(lawyer.id) === String(selectedLawyer))?.name;
     const selectedStatusName = LEGAL_CASE_STATUS_OPTIONS.find((statusOption) => statusOption.value === selectedStatus)?.name;
     const hasClosingDateFilter = Boolean(closingStartDate || closingEndDate);
+    const metricsViewTitles = {
+        general: 'Leitura rápida do período',
+        by_responsible: 'Desempenho por responsável',
+        by_indicator: 'Conversão por indicador',
+    };
+    const metricsViewSubtitles = {
+        general: 'Acompanhe acordos fechados e indicações convertidas no recorte selecionado, respeitando os filtros ativos.',
+        by_responsible: 'Compare o volume fechado por responsável no período atual sem perder os filtros já aplicados no dashboard.',
+        by_indicator: 'Veja quais indicadores mais converteram acordos no período ativo, mantendo a leitura filtrada da operação.',
+    };
 
     const activeFilterChips = [
         buildDateRangeChip('Carteira', portfolioStartDate, portfolioEndDate),
         buildDateRangeChip('Fechamento', closingStartDate, closingEndDate),
-        selectedClientName ? `Cliente: ${selectedClientName}` : null,
-        selectedLawyerName ? `Responsável: ${selectedLawyerName}` : null,
-        selectedStatusName ? `Status: ${selectedStatusName}` : null,
+        ...(isManager
+            ? [
+                selectedClientName ? `Cliente: ${selectedClientName}` : null,
+                selectedLawyerName ? `Responsável: ${selectedLawyerName}` : null,
+                selectedStatusName ? `Status: ${selectedStatusName}` : null,
+            ]
+            : []),
     ].filter(Boolean);
 
     const handleOpenDetailModal = (lawyer) => {
@@ -394,6 +452,10 @@ const DashboardPage = () => {
     const agreementMacroDistribution = Array.isArray(dashboardData?.agreement_macro_distribution)
         ? dashboardData.agreement_macro_distribution
         : [];
+    const viewMetrics = dashboardData?.view_metrics || {};
+    const selectedMetricViewData = viewMetrics?.[selectedMetricsView]?.[selectedMetricsPeriod] || null;
+    const selectedMetricSummary = selectedMetricViewData?.summary || {};
+    const selectedMetricItems = Array.isArray(selectedMetricViewData?.items) ? selectedMetricViewData.items : [];
     const indicatorLeaderboard = Array.isArray(dashboardData?.indicator_leaderboard)
         ? dashboardData.indicator_leaderboard
         : [];
@@ -419,6 +481,37 @@ const DashboardPage = () => {
         indications_received: "Indicações Recebidas",
         agreements_via_indication: "Acordos via Indicação",
         indication_flow_conversion_rate: "Taxa de Indicação"
+    };
+
+    const formatMetricExplorerRange = (metricData) => {
+        const startDate = metricData?.period?.start_date;
+        const endDate = metricData?.period?.end_date;
+
+        if (!startDate && !endDate) {
+            return 'Sem período definido';
+        }
+
+        if (startDate && endDate) {
+            if (startDate === endDate) {
+                return formatFilterDate(startDate);
+            }
+
+            return `${formatFilterDate(startDate)} a ${formatFilterDate(endDate)}`;
+        }
+
+        if (startDate) {
+            return `A partir de ${formatFilterDate(startDate)}`;
+        }
+
+        return `Até ${formatFilterDate(endDate)}`;
+    };
+
+    const formatMetricSummaryValue = (key, value) => {
+        if (['total_agreement_value', 'average_ticket', 'total_economy'].includes(key)) {
+            return formatKpiValue(key, value);
+        }
+
+        return value || 0;
     };
 
     const renderKpiGrid = (data, order) => {
@@ -447,6 +540,90 @@ const DashboardPage = () => {
         );
     };
 
+    const renderMetricExplorerContent = () => {
+        if (!selectedMetricViewData) {
+            return <p className={styles.metricExplorerEmpty}>Não há dados das novas visões para exibir.</p>;
+        }
+
+        if (selectedMetricsView === 'general') {
+            return (
+                <div className={styles.metricSnapshotGrid}>
+                    {GENERAL_PERIOD_METRIC_CARDS.map((card) => (
+                        <KpiCard
+                            key={card.key}
+                            title={card.title}
+                            value={formatMetricSummaryValue(card.key, selectedMetricSummary[card.key])}
+                            description={card.description}
+                        />
+                    ))}
+                </div>
+            );
+        }
+
+        const participantLabel = selectedMetricsView === 'by_indicator' ? 'indicadores' : 'responsáveis';
+
+        if (selectedMetricItems.length === 0) {
+            return (
+                <div className={styles.metricExplorerBody}>
+                    <div className={styles.metricSummaryPills}>
+                        <span className={styles.metricSummaryPill}>0 {participantLabel}</span>
+                        <span className={styles.metricSummaryPill}>0 acordos</span>
+                        <span className={styles.metricSummaryPill}>0 indicações convertidas</span>
+                    </div>
+                    <p className={styles.metricExplorerEmpty}>
+                        Nenhum {selectedMetricsView === 'by_indicator' ? 'indicador' : 'responsável'} apareceu com dados no período selecionado.
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <div className={styles.metricExplorerBody}>
+                <div className={styles.metricSummaryPills}>
+                    <span className={styles.metricSummaryPill}>
+                        {selectedMetricSummary.participants_count || 0} {participantLabel}
+                    </span>
+                    <span className={styles.metricSummaryPill}>
+                        {selectedMetricSummary.agreements_count || 0} acordos
+                    </span>
+                    <span className={styles.metricSummaryPill}>
+                        {selectedMetricSummary.converted_indications_count || 0} indicações convertidas
+                    </span>
+                </div>
+
+                <div className={styles.metricLeaderboardGrid}>
+                    {selectedMetricItems.map((item, index) => (
+                        <article
+                            key={`${selectedMetricsView}-${item.id}-${item.name}`}
+                            className={styles.metricLeaderboardCard}
+                        >
+                            <div className={styles.metricLeaderboardRank}>{index + 1}</div>
+                            <div className={styles.metricLeaderboardContent}>
+                                <div className={styles.metricLeaderboardHeader}>
+                                    <h4 className={styles.metricLeaderboardTitle}>{item.name}</h4>
+                                    <span className={styles.metricLeaderboardBadge}>
+                                        {item.agreements_count || 0} acordos
+                                    </span>
+                                </div>
+
+                                <div className={styles.metricLeaderboardMetrics}>
+                                    <div className={styles.metricLeaderboardMetric}>
+                                        <span>Acordos fechados</span>
+                                        <strong>{item.agreements_count || 0}</strong>
+                                    </div>
+                                    <div className={styles.metricLeaderboardMetric}>
+                                        <span>Indicações convertidas</span>
+                                        <strong>{item.converted_indications_count || 0}</strong>
+                                    </div>
+                                </div>
+                            </div>
+                        </article>
+                    ))}
+                </div>
+            </div>
+        );
+    };
+
     if (isInitialLoading) return <p>Carregando dashboard...</p>;
     if (error && !dashboardData) return <p style={{ color: 'red' }}>{error}</p>;
 
@@ -462,8 +639,8 @@ const DashboardPage = () => {
                 </div>
             )}
 
-            {/* 1. FILTROS (Gestor) */}
-            {isManager && (
+            {/* 1. FILTROS */}
+            {canUsePeriodFilters && (
                 <section className={styles.filters}>
                     <div className={styles.filtersHeader}>
                         <div className={styles.filtersTitleGroup}>
@@ -473,7 +650,9 @@ const DashboardPage = () => {
                             <div>
                                 <h2 className={styles.filtersTitle}>Filtros do Dashboard</h2>
                                 <p className={styles.filtersSubtitle}>
-                                    Separe a leitura entre carteira em andamento e acordos já fechados, mantendo cliente, responsável e status no mesmo painel.
+                                    {isManager
+                                        ? 'Separe a leitura entre carteira em andamento e acordos já fechados, mantendo cliente, responsável e status no mesmo painel.'
+                                        : 'Filtre seus resultados pelos períodos de carteira e fechamento para acompanhar suas métricas no dashboard.'}
                                 </p>
                             </div>
                         </div>
@@ -562,54 +741,56 @@ const DashboardPage = () => {
                         </section>
                     </div>
 
-                    <div className={styles.filtersGrid}>
-                        <div className={styles.filterField}>
-                            <label className={styles.filterLabel}>
-                                <FaBuilding />
-                                <span>Cliente</span>
-                            </label>
-                            <select
-                                className={styles.filterControl}
-                                value={selectedClient}
-                                onChange={(e) => setSelectedClient(e.target.value)}
-                            >
-                                <option value="">Todos</option>
-                                {clients.map((client) => <option key={client.id} value={client.id}>{client.name}</option>)}
-                            </select>
-                        </div>
+                    {isManager && (
+                        <div className={styles.filtersGrid}>
+                            <div className={styles.filterField}>
+                                <label className={styles.filterLabel}>
+                                    <FaBuilding />
+                                    <span>Cliente</span>
+                                </label>
+                                <select
+                                    className={styles.filterControl}
+                                    value={selectedClient}
+                                    onChange={(e) => setSelectedClient(e.target.value)}
+                                >
+                                    <option value="">Todos</option>
+                                    {clients.map((client) => <option key={client.id} value={client.id}>{client.name}</option>)}
+                                </select>
+                            </div>
 
-                        <div className={styles.filterField}>
-                            <label className={styles.filterLabel}>
-                                <FaUserTie />
-                                <span>Responsável</span>
-                            </label>
-                            <select
-                                className={styles.filterControl}
-                                value={selectedLawyer}
-                                onChange={(e) => setSelectedLawyer(e.target.value)}
-                            >
-                                <option value="">Todos</option>
-                                {lawyers.map((lawyer) => <option key={lawyer.id} value={lawyer.id}>{lawyer.name}</option>)}
-                            </select>
-                        </div>
+                            <div className={styles.filterField}>
+                                <label className={styles.filterLabel}>
+                                    <FaUserTie />
+                                    <span>Responsável</span>
+                                </label>
+                                <select
+                                    className={styles.filterControl}
+                                    value={selectedLawyer}
+                                    onChange={(e) => setSelectedLawyer(e.target.value)}
+                                >
+                                    <option value="">Todos</option>
+                                    {lawyers.map((lawyer) => <option key={lawyer.id} value={lawyer.id}>{lawyer.name}</option>)}
+                                </select>
+                            </div>
 
-                        <div className={styles.filterField}>
-                            <label className={styles.filterLabel}>
-                                <FaFlag />
-                                <span>Status</span>
-                            </label>
-                            <select
-                                className={styles.filterControl}
-                                value={selectedStatus}
-                                onChange={(e) => setSelectedStatus(e.target.value)}
-                            >
-                                <option value="">Todos</option>
-                                {LEGAL_CASE_STATUS_OPTIONS.map((statusOption) => (
-                                    <option key={statusOption.value} value={statusOption.value}>{statusOption.name}</option>
-                                ))}
-                            </select>
+                            <div className={styles.filterField}>
+                                <label className={styles.filterLabel}>
+                                    <FaFlag />
+                                    <span>Status</span>
+                                </label>
+                                <select
+                                    className={styles.filterControl}
+                                    value={selectedStatus}
+                                    onChange={(e) => setSelectedStatus(e.target.value)}
+                                >
+                                    <option value="">Todos</option>
+                                    {LEGAL_CASE_STATUS_OPTIONS.map((statusOption) => (
+                                        <option key={statusOption.value} value={statusOption.value}>{statusOption.name}</option>
+                                    ))}
+                                </select>
+                            </div>
                         </div>
-                    </div>
+                    )}
 
                     <div className={styles.filtersFooter}>
                         <div className={styles.filtersSummary}>
@@ -642,6 +823,52 @@ const DashboardPage = () => {
                     </div>
                 </section>
             )}
+
+            <section className={styles.metricExplorerSection}>
+                <div className={styles.metricExplorerHeader}>
+                    <div className={styles.metricExplorerHeading}>
+                        <h2 className={styles.metricExplorerTitle}>{metricsViewTitles[selectedMetricsView]}</h2>
+                        <p className={styles.metricExplorerSubtitle}>{metricsViewSubtitles[selectedMetricsView]}</p>
+                    </div>
+
+                    <div className={styles.metricExplorerRange}>
+                        <span className={styles.metricExplorerRangeLabel}>
+                            {selectedMetricViewData?.period?.label || 'Período'}
+                        </span>
+                        <strong>{formatMetricExplorerRange(selectedMetricViewData)}</strong>
+                    </div>
+                </div>
+
+                <div className={styles.metricExplorerControls}>
+                    <div className={styles.segmentedControl} role="tablist" aria-label="Visões do dashboard">
+                        {METRIC_VIEW_OPTIONS.map((option) => (
+                            <button
+                                key={option.key}
+                                type="button"
+                                className={`${styles.segmentedControlButton} ${selectedMetricsView === option.key ? styles.segmentedControlButtonActive : ''}`}
+                                onClick={() => setSelectedMetricsView(option.key)}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    <div className={styles.segmentedControl} role="tablist" aria-label="Período das métricas">
+                        {METRIC_PERIOD_OPTIONS.map((option) => (
+                            <button
+                                key={option.key}
+                                type="button"
+                                className={`${styles.segmentedControlButton} ${selectedMetricsPeriod === option.key ? styles.segmentedControlButtonActive : ''}`}
+                                onClick={() => setSelectedMetricsPeriod(option.key)}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {renderMetricExplorerContent()}
+            </section>
 
             {/* 2. KPIs (Gestor) */}
             {isManager && (

--- a/concilia-frontend/src/styles/Dashboard.module.css
+++ b/concilia-frontend/src/styles/Dashboard.module.css
@@ -280,6 +280,269 @@ select.filterControl {
     min-width: 0;
 }
 
+.metricExplorerSection {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 1.4rem;
+    border-radius: 24px;
+    border: 1px solid var(--border-color-light);
+    background: linear-gradient(135deg, var(--surface-panel-accent), var(--surface-panel-muted));
+    box-shadow: var(--card-shadow);
+}
+
+.metricExplorerHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.metricExplorerHeading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 260px;
+}
+
+.metricExplorerEyebrow {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    padding: 0.38rem 0.72rem;
+    border-radius: 999px;
+    border: 1px solid var(--accent-border-soft);
+    background: var(--surface-card-glass);
+    color: var(--accent-pill-text);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.metricExplorerTitle {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1.18rem;
+}
+
+.metricExplorerSubtitle {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.93rem;
+    line-height: 1.6;
+    max-width: 68ch;
+}
+
+.metricExplorerRange {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 180px;
+    padding: 0.9rem 1rem;
+    border-radius: 18px;
+    border: 1px solid var(--border-color-light);
+    background: var(--bg-input);
+}
+
+.metricExplorerRangeLabel {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.metricExplorerRange strong {
+    color: var(--text-primary);
+    font-size: 0.96rem;
+    line-height: 1.4;
+}
+
+.metricExplorerControls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.85rem;
+    flex-wrap: wrap;
+}
+
+.segmentedControl {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.35rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-color-light);
+    background: var(--surface-card-muted);
+    flex-wrap: wrap;
+}
+
+.segmentedControlButton {
+    min-height: 40px;
+    padding: 0.65rem 1rem;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+    font-weight: 800;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.segmentedControlButton:hover {
+    color: var(--accent-primary);
+    background: var(--accent-surface);
+}
+
+.segmentedControlButtonActive {
+    background: var(--accent-gradient);
+    color: var(--text-on-accent);
+    box-shadow: var(--accent-shadow);
+}
+
+.metricSnapshotGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.kpiDescription {
+    margin: 0.7rem 0 0;
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+    line-height: 1.5;
+}
+
+.metricExplorerBody {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.metricSummaryPills {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+}
+
+.metricSummaryPill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.55rem 0.85rem;
+    border-radius: 999px;
+    background: var(--accent-surface);
+    border: 1px solid var(--accent-border-soft);
+    color: var(--accent-pill-text);
+    font-size: 0.84rem;
+    font-weight: 700;
+}
+
+.metricLeaderboardGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+}
+
+.metricLeaderboardCard {
+    display: flex;
+    align-items: stretch;
+    gap: 0.9rem;
+    padding: 1rem;
+    border-radius: 20px;
+    border: 1px solid var(--border-color-light);
+    background: var(--bg-card);
+    box-shadow: var(--card-shadow);
+}
+
+.metricLeaderboardRank {
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    background: var(--accent-gradient);
+    color: var(--text-on-accent);
+    font-size: 0.95rem;
+    font-weight: 800;
+    flex-shrink: 0;
+}
+
+.metricLeaderboardContent {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.metricLeaderboardHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.metricLeaderboardTitle {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1rem;
+    line-height: 1.4;
+}
+
+.metricLeaderboardBadge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.42rem 0.72rem;
+    border-radius: 999px;
+    background: var(--accent-pill-bg);
+    border: 1px solid var(--accent-border-soft);
+    color: var(--accent-pill-text);
+    font-size: 0.78rem;
+    font-weight: 800;
+    white-space: nowrap;
+}
+
+.metricLeaderboardMetrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.metricLeaderboardMetric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.28rem;
+    padding: 0.8rem 0.9rem;
+    border-radius: 16px;
+    background: var(--surface-panel-muted);
+    border: 1px solid var(--border-color-light);
+}
+
+.metricLeaderboardMetric span {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    line-height: 1.4;
+}
+
+.metricLeaderboardMetric strong {
+    color: var(--text-primary);
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+.metricExplorerEmpty {
+    margin: 0;
+    padding: 1rem 1.1rem;
+    border-radius: 16px;
+    border: 1px dashed var(--border-color-dark);
+    color: var(--text-secondary);
+    background: var(--surface-card-muted);
+}
+
 .kpiGrid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -833,6 +1096,32 @@ select.filterControl {
     }
 
     .filtersGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .metricExplorerSection {
+        padding: 1.1rem;
+        border-radius: 20px;
+    }
+
+    .metricExplorerRange {
+        width: 100%;
+    }
+
+    .metricExplorerControls {
+        align-items: stretch;
+    }
+
+    .segmentedControl {
+        width: 100%;
+    }
+
+    .segmentedControlButton {
+        flex: 1;
+        justify-content: center;
+    }
+
+    .metricLeaderboardMetrics {
         grid-template-columns: 1fr;
     }
 

--- a/concilia-frontend/src/styles/MainLayout.module.css
+++ b/concilia-frontend/src/styles/MainLayout.module.css
@@ -18,6 +18,7 @@
     box-shadow: var(--sidebar-shadow);
     flex-shrink: 0;
     z-index: 5;
+    overflow-y: auto;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
@@ -112,7 +113,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.55rem;
-    flex: 1;
 }
 
 .navItem {
@@ -207,11 +207,12 @@
 }
 
 .footer {
-    margin-top: auto;
+    margin-top: 0.9rem;
     padding-top: 1rem;
     display: flex;
     flex-direction: column;
     gap: 0.9rem;
+    border-top: 1px solid var(--sidebar-border);
 }
 
 .userInfo {


### PR DESCRIPTION
Habilitei os filtros de período do dashboard para usuários com perfil Operador em DashboardPage.jsx.

Agora ficou assim:

Operador vê a seção de filtros
nessa seção ele tem Carteira e Fechamento
os filtros de Cliente, Responsável e Status continuam só para perfis de gestão
os chips e o contador de filtros também passam a considerar apenas o que o operador realmente pode usar


Removi o rótulo “Nova visualização” da seção do dashboard e, na Visão geral, acrescentei os KPIs por período que você pediu: Total em valores de acordos, Ticket médio e Economia gerada, além dos contadores já existentes. Isso foi ajustado no backend em DashboardController.php e na renderização em DashboardPage.jsx.

Também reposicionei o bloco lateral com nome/função, modo escuro e sair para ficar logo abaixo da navegação, na prática embaixo de Meu Perfil, em vez de ficar empurrado para o fim da sidebar quando a página é longa. Esse ajuste ficou em MainLayout.module.css.

No backend, o dashboard agora retorna uma nova estrutura view_metrics em DashboardController.php, com 3 visões:

general
by_responsible
by_indicator
Cada uma já vem com os períodos day, week e month, trazendo:

agreements_count
converted_indications_count
No frontend, adicionei no DashboardPage.jsx a nova seção com os 3 botões Visão geral, Por Responsável e Por Indicador, além da alternância Dia, Semana e Mês. Também ajustei o visual em Dashboard.module.css. O arquivo .md não está mais no workspace.

Assumi esta regra:

Dia/Semana/Mês usam a data atual como referência
o recorte cruza com o filtro de fechamento já existente no dashboard
cliente, status e responsável continuam sendo respeitados normalmente