### PR TITLE
Modificando a lógica da contabilização de Acordos Fechados, e atualiz…

### DIFF
--- a/concilia-backend/src/app/Http/Controllers/Api/DashboardController.php
+++ b/concilia-backend/src/app/Http/Controllers/Api/DashboardController.php
@@ -85,8 +85,8 @@ class DashboardController extends Controller
             )
             ->selectRaw('COALESCE(SUM(COALESCE(original_value, 0)), 0) as total_original_value')
             ->selectRaw(
-                'COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as closed_cases',
-                [LegalCase::STATUS_CLOSED_DEAL]
+                "COALESCE(SUM(CASE WHEN {$this->agreementMetricStatusCaseSql()} THEN 1 ELSE 0 END), 0) as closed_cases",
+                LegalCase::AGREEMENT_METRIC_STATUSES
             )
             ->selectRaw(
                 'COALESCE(SUM(CASE WHEN status NOT IN (?, ?, ?) THEN 1 ELSE 0 END), 0) as active_cases',
@@ -131,8 +131,8 @@ class DashboardController extends Controller
         $indicationKpiRow = $indicationCasesQuery
             ->selectRaw('COUNT(*) as indications_received')
             ->selectRaw(
-                'COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as agreements_via_indication',
-                [LegalCase::STATUS_CLOSED_DEAL]
+                "COALESCE(SUM(CASE WHEN {$this->agreementMetricStatusCaseSql()} THEN 1 ELSE 0 END), 0) as agreements_via_indication",
+                LegalCase::AGREEMENT_METRIC_STATUSES
             )
             ->first();
 
@@ -319,12 +319,12 @@ class DashboardController extends Controller
                 [LegalCase::STATUS_INITIAL_ANALYSIS]
             )
             ->selectRaw(
-                'COALESCE(SUM(CASE WHEN legal_cases.status = ? THEN 1 ELSE 0 END), 0) as closed_deals',
-                [LegalCase::STATUS_CLOSED_DEAL]
+                "COALESCE(SUM(CASE WHEN {$this->agreementMetricStatusCaseSql('legal_cases.status')} THEN 1 ELSE 0 END), 0) as closed_deals",
+                LegalCase::AGREEMENT_METRIC_STATUSES
             )
             ->selectRaw(
-                'COALESCE(SUM(CASE WHEN legal_cases.status = ? THEN COALESCE(legal_cases.original_value, 0) - COALESCE(legal_cases.agreement_value, 0) ELSE 0 END), 0) as economy',
-                [LegalCase::STATUS_CLOSED_DEAL]
+                "COALESCE(SUM(CASE WHEN {$this->agreementMetricStatusCaseSql('legal_cases.status')} THEN COALESCE(legal_cases.original_value, 0) - COALESCE(legal_cases.agreement_value, 0) ELSE 0 END), 0) as economy",
+                LegalCase::AGREEMENT_METRIC_STATUSES
             )
             ->leftJoin('legal_cases', function (JoinClause $join) use ($request, $dateRange) {
                 $join->on('legal_cases.user_id', '=', 'users.id');
@@ -500,8 +500,8 @@ class DashboardController extends Controller
             ->selectRaw("COALESCE(indicators.name, 'Indicador indisponivel') as indicator_name")
             ->selectRaw('COUNT(*) as indications_count')
             ->selectRaw(
-                'COALESCE(SUM(CASE WHEN legal_cases.status = ? THEN 1 ELSE 0 END), 0) as closed_deals',
-                [LegalCase::STATUS_CLOSED_DEAL]
+                "COALESCE(SUM(CASE WHEN {$this->agreementMetricStatusCaseSql('legal_cases.status')} THEN 1 ELSE 0 END), 0) as closed_deals",
+                LegalCase::AGREEMENT_METRIC_STATUSES
             )
             ->groupBy('legal_cases.indicator_user_id', 'indicators.name')
             ->orderByDesc('closed_deals')
@@ -621,10 +621,17 @@ class DashboardController extends Controller
         ?string $dateColumn = 'agreement_closed_at'
     ): Builder {
         $query = $this->newFilteredCaseQuery($request, $user, $dateRange, $dateColumn);
-        $query->where($this->qualifyLegalCaseColumn('status'), LegalCase::STATUS_CLOSED_DEAL);
+        $query->whereIn($this->qualifyLegalCaseColumn('status'), LegalCase::AGREEMENT_METRIC_STATUSES);
         $query->whereNotNull($this->qualifyLegalCaseColumn('agreement_closed_at'));
 
         return $query;
+    }
+
+    private function agreementMetricStatusCaseSql(string $column = 'status'): string
+    {
+        $placeholders = implode(', ', array_fill(0, count(LegalCase::AGREEMENT_METRIC_STATUSES), '?'));
+
+        return "{$column} IN ({$placeholders})";
     }
 
     private function resolveRecentCasesPerPage(Request $request): int

--- a/concilia-backend/src/app/Http/Controllers/Api/LegalCaseController.php
+++ b/concilia-backend/src/app/Http/Controllers/Api/LegalCaseController.php
@@ -762,18 +762,50 @@ class LegalCaseController extends Controller
                 }
 
                 $existingCase = $this->findExistingCaseForImport($caseData['case_number'] ?? null);
-                $caseData = $this->applyImportPartyFallbacks($caseData, $clientName, $existingCase);
-
                 if (empty($caseData['original_value'])) {
                     $caseData['original_value'] = $existingCase?->original_value ?? 0;
-                }
-                if (empty($caseData['cause_value'])) {
-                    $caseData['cause_value'] = $caseData['original_value'] ?? 0;
                 }
                 $caseData['has_alcada'] = $this->resolveImportedHasAlcada(
                     $caseData['original_value'] ?? null,
                     $existingCase
                 );
+
+                if ($existingCase) {
+                    $payload = $this->buildExistingCaseAlcadaImportPayload($caseData, $existingCase);
+
+                    $validator = Validator::make($payload, [
+                        'case_number' => 'required|string|max:255',
+                        'original_value' => 'required|numeric',
+                        'has_alcada' => 'nullable|boolean',
+                    ], $messages, $customAttributes);
+
+                    if ($validator->fails()) {
+                        $errors[] = [
+                            'line' => "Registro " . ($index + 1),
+                            'errors' => $validator->errors()->all(),
+                        ];
+                    } else {
+                        try {
+                            $existingCase->fill($payload);
+                            $existingCase->save();
+                            $updatedCount++;
+                            $successCount++;
+                        } catch (\Exception $e) {
+                            $errors[] = [
+                                'line' => "Registro " . ($index + 1),
+                                'errors' => ["Erro técnico ao salvar (Verifique dados inválidos ou caracteres especiais): " . $e->getMessage()]
+                            ];
+                        }
+                    }
+
+                    continue;
+                }
+
+                $caseData = $this->applyImportPartyFallbacks($caseData, $clientName, $existingCase);
+
+                if (empty($caseData['cause_value'])) {
+                    $caseData['cause_value'] = $caseData['original_value'] ?? 0;
+                }
 
                 unset($caseData['updated_condemnation_value']);
 
@@ -951,8 +983,6 @@ class LegalCaseController extends Controller
                 }
 
                 $existingCase = $this->findExistingCaseForImport($caseData['case_number'] ?? null);
-                $caseData = $this->applyImportPartyFallbacks($caseData, $clientName, $existingCase);
-
                 // Para sync de alçada, SEMPRE recalcular original_value do portal_agreement_offers
                 if (!empty($caseData['portal_agreement_offers'])) {
                     $pendingValue = $this->extractCurrentPortalAgreementValue(
@@ -973,6 +1003,41 @@ class LegalCaseController extends Controller
                 if (empty($caseData['original_value'])) {
                     $caseData['original_value'] = $existingCase?->original_value ?? 0;
                 }
+
+                if ($existingCase) {
+                    $payload = $this->buildExistingCaseAlcadaImportPayload($caseData, $existingCase);
+
+                    $validator = Validator::make($payload, [
+                        'case_number' => 'required|string|max:255',
+                        'original_value' => 'nullable|numeric',
+                        'has_alcada' => 'nullable|boolean',
+                    ], $messages, $customAttributes);
+
+                    if ($validator->fails()) {
+                        $errors[] = [
+                            'line' => "Registro " . ($index + 1),
+                            'errors' => $validator->errors()->all()
+                        ];
+                    } else {
+                        try {
+                            $existingCase->fill($payload);
+                            $existingCase->save();
+                            $processedCaseIds[] = $existingCase->id;
+                            $updatedCount++;
+                            $successCount++;
+                        } catch (\Exception $e) {
+                            $errors[] = [
+                                'line' => "Registro " . ($index + 1),
+                                'errors' => ["Erro ao salvar: " . $e->getMessage()]
+                            ];
+                        }
+                    }
+
+                    continue;
+                }
+
+                $caseData = $this->applyImportPartyFallbacks($caseData, $clientName, $existingCase);
+
                 if (empty($caseData['cause_value'])) {
                     $caseData['cause_value'] = $caseData['original_value'] ?? 0;
                 }
@@ -1497,6 +1562,15 @@ class LegalCaseController extends Controller
             $payload,
             static fn ($value) => $value !== ''
         );
+    }
+
+    private function buildExistingCaseAlcadaImportPayload(array $caseData, LegalCase $existingCase): array
+    {
+        return [
+            'case_number' => $existingCase->case_number,
+            'original_value' => $caseData['original_value'] ?? $existingCase->original_value ?? 0,
+            'has_alcada' => $caseData['has_alcada'] ?? $existingCase->has_alcada ?? false,
+        ];
     }
 
     private function resolveImportedHasAlcada(mixed $originalValue, ?LegalCase $existingCase): bool
@@ -2160,7 +2234,7 @@ class LegalCaseController extends Controller
         }
 
         $resolvedStatus = $payload['status'] ?? $existingCase?->status;
-        if ($resolvedStatus !== LegalCase::STATUS_CLOSED_DEAL) {
+        if (!in_array($resolvedStatus, LegalCase::AGREEMENT_METRIC_STATUSES, true)) {
             return [];
         }
 

--- a/concilia-backend/src/app/Models/LegalCase.php
+++ b/concilia-backend/src/app/Models/LegalCase.php
@@ -27,6 +27,11 @@ class LegalCase extends Model
     public const STATUS_CLOSED_DEAL = 'closed_deal';
     public const STATUS_FAILED_DEAL = 'failed_deal';
 
+    public const AGREEMENT_METRIC_STATUSES = [
+        self::STATUS_AWAITING_DRAFT,
+        self::STATUS_CLOSED_DEAL,
+    ];
+
     public const STATUSES = [
         self::STATUS_INITIAL_ANALYSIS,
         self::STATUS_INDICATIONS,

--- a/concilia-backend/src/database/migrations/2026_04_23_120000_backfill_agreement_closed_at_for_agreement_metric_statuses.php
+++ b/concilia-backend/src/database/migrations/2026_04_23_120000_backfill_agreement_closed_at_for_agreement_metric_statuses.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\LegalCase;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('legal_cases')
+            ->whereIn('status', LegalCase::AGREEMENT_METRIC_STATUSES)
+            ->whereNull('agreement_closed_at')
+            ->update([
+                'agreement_closed_at' => DB::raw('DATE(updated_at)'),
+            ]);
+    }
+
+    public function down(): void
+    {
+        // Backfill de dados apenas.
+    }
+};

--- a/concilia-backend/src/tests/Feature/CaseImportTest.php
+++ b/concilia-backend/src/tests/Feature/CaseImportTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\LegalCase;
+use App\Models\OpposingLawyer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class CaseImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_import_updates_only_alcada_for_existing_cases(): void
+    {
+        $manager = User::factory()->create([
+            'role' => 'administrador',
+            'status' => 'ativo',
+        ]);
+
+        $operator = User::factory()->create([
+            'role' => 'operador',
+            'status' => 'ativo',
+        ]);
+
+        $client = Client::create([
+            'name' => 'Cliente Importacao',
+        ]);
+
+        $opposingLawyer = OpposingLawyer::create([
+            'name' => 'Advogado Adverso Correto',
+        ]);
+
+        $legalCase = LegalCase::create([
+            'client_id' => $client->id,
+            'user_id' => $operator->id,
+            'case_number' => '08011957020268205004',
+            'opposing_party' => 'Autor Correto',
+            'defendant' => 'Reu Correto',
+            'action_object' => 'Objeto correto',
+            'status' => LegalCase::STATUS_INITIAL_ANALYSIS,
+            'priority' => 'media',
+            'original_value' => 1000,
+            'cause_value' => 1000,
+            'opposing_lawyer' => $opposingLawyer->name,
+            'opposing_lawyer_id' => $opposingLawyer->id,
+            'description' => 'Descricao correta',
+        ]);
+
+        Sanctum::actingAs($manager);
+
+        $this->postJson('/api/cases/import', [
+            'client_id' => $client->id,
+            'cases' => [[
+                'case_number' => $legalCase->case_number,
+                'original_value' => '2500',
+                'opposing_lawyer' => '',
+                'opposing_party' => '',
+                'defendant' => '',
+            ]],
+        ])->assertCreated()
+            ->assertJsonPath('success_count', 1)
+            ->assertJsonPath('created_count', 0)
+            ->assertJsonPath('updated_count', 1);
+
+        $legalCase->refresh();
+
+        $this->assertSame(2500.0, (float) $legalCase->original_value);
+        $this->assertTrue((bool) $legalCase->has_alcada);
+        $this->assertSame($opposingLawyer->name, $legalCase->opposing_lawyer);
+        $this->assertSame($opposingLawyer->id, $legalCase->opposing_lawyer_id);
+        $this->assertSame('Autor Correto', $legalCase->opposing_party);
+        $this->assertSame('Reu Correto', $legalCase->defendant);
+        $this->assertSame('Descricao correta', $legalCase->description);
+        $this->assertSame($operator->id, $legalCase->user_id);
+    }
+}

--- a/concilia-backend/src/tests/Feature/DashboardMetricsTest.php
+++ b/concilia-backend/src/tests/Feature/DashboardMetricsTest.php
@@ -638,6 +638,71 @@ class DashboardMetricsTest extends TestCase
         }
     }
 
+    public function test_dashboard_counts_awaiting_draft_in_agreement_metrics(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-04-23 10:00:00'));
+
+        try {
+            $manager = User::factory()->create([
+                'role' => 'administrador',
+                'status' => 'ativo',
+            ]);
+
+            $operator = User::factory()->create([
+                'role' => 'operador',
+                'status' => 'ativo',
+            ]);
+
+            $indicator = User::factory()->create([
+                'name' => 'Indicador Um',
+                'role' => 'indicador',
+                'status' => 'ativo',
+            ]);
+
+            Sanctum::actingAs($manager);
+
+            $this->createLegalCase($operator, LegalCase::STATUS_CLOSED_DEAL, 'AGREEMENT-CLOSED', [
+                'original_value' => 2000,
+                'agreement_value' => 1200,
+                'agreement_closed_at' => '2026-04-23',
+                'indicator_user_id' => $indicator->id,
+                'agreement_checklist_data' => [
+                    'indication_checklist' => [
+                        'completed_at' => '2026-04-18T09:00:00-03:00',
+                    ],
+                ],
+            ]);
+
+            $this->createLegalCase($operator, LegalCase::STATUS_AWAITING_DRAFT, 'AGREEMENT-DRAFT', [
+                'original_value' => 1500,
+                'agreement_value' => 900,
+                'updated_at' => Carbon::parse('2026-04-22 11:00:00'),
+                'indicator_user_id' => $indicator->id,
+                'agreement_checklist_data' => [
+                    'indication_checklist' => [
+                        'completed_at' => '2026-04-19T15:30:00-03:00',
+                    ],
+                ],
+            ]);
+
+            $response = $this->getJson('/api/dashboard?closing_start_date=2026-04-01&closing_end_date=2026-04-30');
+
+            $response
+                ->assertOk()
+                ->assertJsonPath('kpis.closed_deals_today', 2)
+                ->assertJsonPath('kpis.total_agreement_value', 2100)
+                ->assertJsonPath('kpis.average_ticket', 1050)
+                ->assertJsonPath('kpis.total_economy', 1400)
+                ->assertJsonPath('indication_metrics.agreements_via_indication', 2)
+                ->assertJsonPath('view_metrics.general.month.summary.agreements_count', 2)
+                ->assertJsonPath('view_metrics.by_responsible.month.items.0.agreements_count', 2)
+                ->assertJsonPath('team_performance.0.closed_deals', 2)
+                ->assertJsonPath('indicator_leaderboard.0.closed_deals', 2);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     private function createLegalCase(User $operator, string $status, string $caseNumber, array $overrides = []): LegalCase
     {
         $client = Client::firstOrCreate([
@@ -661,7 +726,7 @@ class DashboardMetricsTest extends TestCase
             'updated_at',
         ])));
 
-        if ($status === LegalCase::STATUS_CLOSED_DEAL && !array_key_exists('agreement_closed_at', $payload)) {
+        if (in_array($status, LegalCase::AGREEMENT_METRIC_STATUSES, true) && !array_key_exists('agreement_closed_at', $payload)) {
             $referenceDate = $overrides['updated_at'] ?? $overrides['created_at'] ?? now();
             $payload['agreement_closed_at'] = Carbon::parse($referenceDate)->toDateString();
         }

--- a/concilia-frontend/src/components/KpiCard.jsx
+++ b/concilia-frontend/src/components/KpiCard.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import CountUp from 'react-countup'; // Importando a biblioteca
 import styles from '../styles/Dashboard.module.css';
+import MetricInfoHint from './MetricInfoHint';
 
 // Função auxiliar para extrair o número e os prefixos/sufixos do texto
 const parseValue = (valueString) => {
@@ -48,13 +49,16 @@ const parseValue = (valueString) => {
 };
 
 
-const KpiCard = ({ title, value, description }) => {
+const KpiCard = ({ title, value, description, infoTooltip }) => {
     // Analisa o valor para extrair as partes
     const { prefix, endValue, suffix, decimals, isNaN } = parseValue(value);
 
     return (
         <div className={styles.kpiCard}>
-            <h3 className={styles.kpiTitle}>{title}</h3>
+            <div className={styles.kpiTitleRow}>
+                <h3 className={styles.kpiTitle}>{title}</h3>
+                {infoTooltip && <MetricInfoHint text={infoTooltip} />}
+            </div>
             
             {/* Usamos o CountUp aqui.
               Se o valor não for um número (isNaN), ele apenas mostra o texto original.

--- a/concilia-frontend/src/components/LawyerDetailModal.jsx
+++ b/concilia-frontend/src/components/LawyerDetailModal.jsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react';
 import styles from '../styles/LawyerDetailModal.module.css';
 import DetailKpiCard from './DetailKpiCard';
 import { FaTimes } from 'react-icons/fa';
+import MetricInfoHint from './MetricInfoHint';
+import { AGREEMENT_COUNT_INFO_TEXT } from '../constants/dashboardMetrics';
 
 const LawyerDetailModal = ({ isOpen, onClose, lawyer }) => {
     
@@ -93,7 +95,12 @@ const LawyerDetailModal = ({ isOpen, onClose, lawyer }) => {
                         subtext="Em andamento" 
                     />
                     <DetailKpiCard 
-                        title="Acordos Fechados" 
+                        title={(
+                            <span className={styles.titleWithInfo}>
+                                <span>Acordos Fechados</span>
+                                <MetricInfoHint text={AGREEMENT_COUNT_INFO_TEXT} />
+                            </span>
+                        )}
                         value={dealsCount} 
                         subtext="Total acumulado" 
                     />

--- a/concilia-frontend/src/components/LawyerPerformanceCard.jsx
+++ b/concilia-frontend/src/components/LawyerPerformanceCard.jsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import styles from '../styles/LawyerPerformanceCard.module.css';
 import { FaTrophy } from 'react-icons/fa';
+import MetricInfoHint from './MetricInfoHint';
+import { AGREEMENT_COUNT_INFO_TEXT } from '../constants/dashboardMetrics';
 
 // Adicione a nova prop 'onViewDetails'
 const LawyerPerformanceCard = ({ lawyer, rank, onViewDetails }) => {
@@ -40,7 +42,10 @@ const LawyerPerformanceCard = ({ lawyer, rank, onViewDetails }) => {
                         <span className={styles.valueBlue}>{lawyer.performance.conversion}%</span>
                     </div>
                     <div className={styles.metric}>
-                        <span>Acordos:</span>
+                        <span className={styles.metricLabelWithInfo}>
+                            <span>Acordos:</span>
+                            <MetricInfoHint text={AGREEMENT_COUNT_INFO_TEXT} />
+                        </span>
                         <span>{lawyer.performance.deals}</span>
                     </div>
                 </div>

--- a/concilia-frontend/src/components/MetricInfoHint.jsx
+++ b/concilia-frontend/src/components/MetricInfoHint.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { FaInfoCircle } from 'react-icons/fa';
+import styles from '../styles/MetricInfoHint.module.css';
+
+const MetricInfoHint = ({ text, className = '' }) => {
+    const classes = className ? `${styles.wrapper} ${className}` : styles.wrapper;
+
+    return (
+        <span className={classes}>
+            <span
+                className={styles.trigger}
+                tabIndex={0}
+                aria-label={text}
+                title={text}
+            >
+                <FaInfoCircle aria-hidden="true" />
+            </span>
+            <span className={styles.tooltip} role="tooltip">
+                {text}
+            </span>
+        </span>
+    );
+};
+
+export default MetricInfoHint;

--- a/concilia-frontend/src/components/TopIndicatorsPanel.jsx
+++ b/concilia-frontend/src/components/TopIndicatorsPanel.jsx
@@ -1,5 +1,7 @@
 import React, { useMemo, useState } from 'react';
+import MetricInfoHint from './MetricInfoHint';
 import styles from '../styles/TopIndicatorsPanel.module.css';
+import { AGREEMENT_COUNT_INFO_TEXT } from '../constants/dashboardMetrics';
 
 const formatPercent = (value) =>
   new Intl.NumberFormat('pt-BR', {
@@ -82,7 +84,10 @@ const TopIndicatorsPanel = ({
 
                 <div className={styles.metrics}>
                   <span>{indicator.indications_count} indicações</span>
-                  <span>{closedDeals} acordos fechados</span>
+                  <span className={styles.metricWithInfo}>
+                    <span>{closedDeals} acordos fechados</span>
+                    <MetricInfoHint text={AGREEMENT_COUNT_INFO_TEXT} />
+                  </span>
                 </div>
 
                 <div className={styles.progressTrack}>

--- a/concilia-frontend/src/constants/dashboardMetrics.js
+++ b/concilia-frontend/src/constants/dashboardMetrics.js
@@ -1,0 +1,1 @@
+export const AGREEMENT_COUNT_INFO_TEXT = 'Esse quantitativo considera casos em Acordo Fechado e Aguardando Minuta.';

--- a/concilia-frontend/src/pages/DashboardPage.jsx
+++ b/concilia-frontend/src/pages/DashboardPage.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext';
 import apiClient from '../api';
 import CasesTable from '../components/CasesTable';
 import KpiCard from '../components/KpiCard';
+import MetricInfoHint from '../components/MetricInfoHint';
 import StatusDistributionChart from '../components/StatusDistributionChartJS';
 import ProcessStageChart from '../components/ProcessStageChart';
 import MonthlyEvolutionChart from '../components/MonthlyEvolutionChart';
@@ -30,11 +31,11 @@ import {
 import styles from '../styles/Dashboard.module.css';
 import { Link } from 'react-router-dom';
 import { LEGAL_CASE_STATUS_OPTIONS, UNASSIGNED_RESPONSIBLE_VALUE } from '../constants/legalCaseStatus';
+import { AGREEMENT_COUNT_INFO_TEXT } from '../constants/dashboardMetrics';
 
 const GENERAL_KPI_ORDER = [
     'total_cases',
     'active_cases',
-    'closed_deals_today',
     'total_original_value',
     'total_agreement_value',
     'average_ticket',
@@ -66,7 +67,8 @@ const GENERAL_PERIOD_METRIC_CARDS = [
     {
         key: 'agreements_count',
         title: 'Acordos fechados',
-        description: 'Fechamentos do período selecionado',
+        description: 'Fechamentos e casos aguardando minuta do período selecionado',
+        infoTooltip: AGREEMENT_COUNT_INFO_TEXT,
     },
     {
         key: 'converted_indications_count',
@@ -188,7 +190,7 @@ const DashboardPage = () => {
         by_indicator: 'Conversão por indicador',
     };
     const metricsViewSubtitles = {
-        general: 'Acompanhe acordos fechados e indicações convertidas no recorte selecionado, respeitando os filtros ativos.',
+        general: 'Acompanhe acordos fechados, incluindo aguardando minuta, e indicações convertidas no recorte selecionado, respeitando os filtros ativos.',
         by_responsible: 'Compare o volume fechado por responsável no período atual sem perder os filtros já aplicados no dashboard.',
         by_indicator: 'Veja quais indicadores mais converteram acordos no período ativo, mantendo a leitura filtrada da operação.',
     };
@@ -516,6 +518,20 @@ const DashboardPage = () => {
         return value || 0;
     };
 
+    const renderAgreementCountLabel = (value, label = 'acordos') => (
+        <span className={styles.metricInlineInfo}>
+            <span>{value} {label}</span>
+            <MetricInfoHint text={AGREEMENT_COUNT_INFO_TEXT} />
+        </span>
+    );
+
+    const renderAgreementMetricLabel = (label) => (
+        <span className={styles.metricInlineInfo}>
+            <span>{label}</span>
+            <MetricInfoHint text={AGREEMENT_COUNT_INFO_TEXT} />
+        </span>
+    );
+
     const renderKpiGrid = (data, order) => {
         if (!data) {
             return <p>Não há dados de KPI para exibir.</p>;
@@ -536,6 +552,7 @@ const DashboardPage = () => {
                         key={key}
                         title={kpiTitles[key] || key}
                         value={formatKpiValue(key, value)}
+                        infoTooltip={key === 'closed_deals_today' ? AGREEMENT_COUNT_INFO_TEXT : undefined}
                     />
                 ))}
             </div>
@@ -556,6 +573,7 @@ const DashboardPage = () => {
                             title={card.title}
                             value={formatMetricSummaryValue(card.key, selectedMetricSummary[card.key])}
                             description={card.description}
+                            infoTooltip={card.infoTooltip}
                         />
                     ))}
                 </div>
@@ -586,7 +604,7 @@ const DashboardPage = () => {
                         {selectedMetricSummary.participants_count || 0} {participantLabel}
                     </span>
                     <span className={styles.metricSummaryPill}>
-                        {selectedMetricSummary.agreements_count || 0} acordos
+                        {renderAgreementCountLabel(selectedMetricSummary.agreements_count || 0)}
                     </span>
                     <span className={styles.metricSummaryPill}>
                         {selectedMetricSummary.converted_indications_count || 0} indicações convertidas
@@ -604,13 +622,13 @@ const DashboardPage = () => {
                                 <div className={styles.metricLeaderboardHeader}>
                                     <h4 className={styles.metricLeaderboardTitle}>{item.name}</h4>
                                     <span className={styles.metricLeaderboardBadge}>
-                                        {item.agreements_count || 0} acordos
+                                        {renderAgreementCountLabel(item.agreements_count || 0)}
                                     </span>
                                 </div>
 
                                 <div className={styles.metricLeaderboardMetrics}>
                                     <div className={styles.metricLeaderboardMetric}>
-                                        <span>Acordos fechados</span>
+                                        <span>{renderAgreementMetricLabel('Acordos fechados')}</span>
                                         <strong>{item.agreements_count || 0}</strong>
                                     </div>
                                     <div className={styles.metricLeaderboardMetric}>
@@ -880,7 +898,7 @@ const DashboardPage = () => {
                         <div className={styles.kpiSectionHeader}>
                             <h3 className={styles.kpiSectionTitle}>Visão Geral de Acordos</h3>
                             <p className={styles.kpiSectionSubtitle}>
-                                Casos, status e conversão seguem o período da carteira; métricas de acordo fechado respeitam a data real do fechamento.
+                                Casos, status e conversão seguem o período da carteira; métricas de acordo fechado consideram também aguardando minuta e respeitam a data real do fechamento.
                             </p>
                         </div>
                         {renderKpiGrid(dashboardData?.kpis, GENERAL_KPI_ORDER)}

--- a/concilia-frontend/src/styles/Dashboard.module.css
+++ b/concilia-frontend/src/styles/Dashboard.module.css
@@ -409,6 +409,12 @@ select.filterControl {
     gap: 1rem;
 }
 
+.metricInlineInfo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.38rem;
+}
+
 .kpiDescription {
     margin: 0.7rem 0 0;
     color: var(--text-secondary);
@@ -545,7 +551,7 @@ select.filterControl {
 
 .kpiGrid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1.5rem;
 }
 
@@ -640,6 +646,7 @@ select.filterControl {
     cursor: pointer;
     transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
     box-shadow: var(--card-shadow);
+    min-width: 0;
 }
 
 .kpiCard:hover {
@@ -647,17 +654,26 @@ select.filterControl {
     box-shadow: var(--card-shadow-strong);
 }
 
+.kpiTitleRow {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-bottom: 0.5rem;
+}
+
 .kpiTitle {
-    margin: 0 0 0.5rem 0;
+    margin: 0;
     font-size: 1rem;
     color: var(--text-secondary);
 }
 
 .kpiValue {
     margin: 0;
-    font-size: 1.75rem;
+    font-size: clamp(1.5rem, 1.25rem + 0.8vw, 1.75rem);
     font-weight: bold;
-    word-break: break-all;
+    white-space: nowrap;
+    word-break: normal;
+    overflow-wrap: normal;
     color: var(--text-primary);
 }
 
@@ -1076,6 +1092,12 @@ select.filterControl {
     transform: translateX(2px);
 }
 
+@media (max-width: 1180px) {
+    .kpiGrid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
 @media (max-width: 768px) {
     .filters {
         padding: 1.1rem;
@@ -1176,5 +1198,9 @@ select.filterControl {
     .recentCasesPagination {
         width: 100%;
         justify-content: flex-start;
+    }
+
+    .kpiGrid {
+        grid-template-columns: 1fr;
     }
 }

--- a/concilia-frontend/src/styles/LawyerDetailModal.module.css
+++ b/concilia-frontend/src/styles/LawyerDetailModal.module.css
@@ -118,6 +118,12 @@
     color: var(--text-primary) !important;
 }
 
+.titleWithInfo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
 /* --- SEÇÃO DE PROGRESSO --- */
 .progressSection h3 {
     margin: 0 0 1rem 0;

--- a/concilia-frontend/src/styles/LawyerPerformanceCard.module.css
+++ b/concilia-frontend/src/styles/LawyerPerformanceCard.module.css
@@ -80,6 +80,12 @@
     margin-bottom: 0.5rem;
 }
 
+.metricLabelWithInfo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
 .metric span:first-child {
     color: var(--text-secondary); /* CORRIGIDO */
 }

--- a/concilia-frontend/src/styles/MetricInfoHint.module.css
+++ b/concilia-frontend/src/styles/MetricInfoHint.module.css
@@ -1,0 +1,54 @@
+.wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.trigger {
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--accent-surface);
+    color: var(--accent-primary);
+    cursor: help;
+    line-height: 1;
+    box-shadow: inset 0 0 0 1px var(--accent-border-soft);
+}
+
+.trigger svg {
+    width: 11px;
+    height: 11px;
+}
+
+.tooltip {
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 0.55rem);
+    z-index: 40;
+    width: min(240px, calc(100vw - 32px));
+    padding: 0.7rem 0.8rem;
+    border-radius: 12px;
+    border: 1px solid var(--accent-border-soft);
+    background: var(--surface-card-elevated);
+    color: var(--text-primary);
+    font-size: 0.78rem;
+    line-height: 1.45;
+    box-shadow: var(--card-shadow-strong);
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, 6px);
+    transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
+    pointer-events: none;
+    text-align: left;
+}
+
+.wrapper:hover .tooltip,
+.wrapper:focus-within .tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0);
+}

--- a/concilia-frontend/src/styles/TopIndicatorsPanel.module.css
+++ b/concilia-frontend/src/styles/TopIndicatorsPanel.module.css
@@ -100,6 +100,12 @@
   font-size: 0.84rem;
 }
 
+.metricWithInfo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .progressTrack {
   width: 100%;
   height: 8px;


### PR DESCRIPTION
Ajustei o dashboard para que as métricas de acordo passem a considerar Acordo Fechado + Aguardando Minuta, e adicionei o ícone i com tooltip explicando isso nos principais pontos onde esse total aparece. Também removi Acordos Fechados Hoje da seção “Visão Geral de Acordos”, reorganizei os cards dessa seção em 3 por linha e impedi a quebra visual dos valores monetários em DashboardPage.jsx (line 36), Dashboard.module.css (line 552) e MetricInfoHint.jsx (line 5).

No backend, a regra do dashboard agora soma esses dois status nas métricas de acordo em DashboardController.php (line 88), passa a preservar/preencher agreement_closed_at também para awaiting_draft em LegalCaseController.php (line 2163) e inclui um backfill para dados antigos na migration 2026_04_23_120000_backfill_agreement_closed_at_for_agreement_metric_statuses.php (line 12). O frontend compilou com npm run build, e o teste isolado novo do backend passou via Docker. Ao rodar o arquivo inteiro de testes do dashboard apareceram falhas antigas não relacionadas a esse ajuste, então a validação completa do backend ainda está pendente dessas inconsistências pré-existentes.


A importação foi ajustada para que, quando o processo já existir, a planilha atualize apenas a alçada (original_value) e o has_alcada, sem mexer em advogado adverso, partes, responsável, descrição e demais campos já salvos. A criação de casos novos continua com a lógica anterior. A mudança ficou em LegalCaseController.php (line 773) e apliquei a mesma proteção também no fluxo de sincronização de alçada em LegalCaseController.php (line 1007).

Também deixei um teste cobrindo exatamente esse cenário em CaseImportTest.php (line 17): importação de um caso existente com advogado adverso em branco preserva o advogado adverso e atualiza só a alçada. Validei esse teste no backend via Docker, e ele passou.